### PR TITLE
Add generic Makefile with common targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+# Makefile for general project management
+
+# Default target
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  install    - Install project dependencies"
+	@echo "  build     - Build the project"
+	@echo "  test      - Run tests"
+	@echo "  clean     - Remove build artifacts"
+	@echo "  run       - Run the project"
+	@echo "  lint      - Run linter"
+
+# Install dependencies
+.PHONY: install
+install:
+	@echo "Installing dependencies..."
+	# Add your package manager command here, e.g.:
+	# pip install -r requirements.txt
+
+# Build project
+.PHONY: build
+build:
+	@echo "Building project..."
+	# Add your build command here, e.g.:
+	# python setup.py build
+
+# Run tests
+.PHONY: test
+test:
+	@echo "Running tests..."
+	# Add your test command here, e.g.:
+	# python -m pytest
+
+# Clean build artifacts
+.PHONY: clean
+clean:
+	@echo "Cleaning build artifacts..."
+	# Add cleanup commands, e.g.:
+	# rm -rf build/
+	# rm -rf *.egg-info
+
+# Run the project
+.PHONY: run
+run:
+	@echo "Running project..."
+	# Add your run command here, e.g.:
+	# python main.py
+
+# Run linter
+.PHONY: lint
+lint:
+	@echo "Running linter..."
+	# Add linter command here, e.g.:
+	# flake8 . or pylint .


### PR DESCRIPTION
## Description

This pull request adds a generic Makefile to the repository with standard targets:

- `help`: Display available targets
- `install`: Install project dependencies
- `build`: Build the project
- `test`: Run tests
- `clean`: Remove build artifacts
- `run`: Execute the project
- `lint`: Run code linter

The Makefile is designed to be adaptable and can be customized based on the specific project requirements.

### Rationale

A standardized Makefile provides:
- Consistent project management commands
- Easy-to-use development workflow
- Simplified project setup and maintenance

### Next Steps

- Replace placeholder commands with actual project-specific implementations
- Add more targets as needed
